### PR TITLE
Create AI real estate pro marketing

### DIFF
--- a/AI real estate pro marketing
+++ b/AI real estate pro marketing
@@ -1,0 +1,46 @@
+Real estate pros are bogged down by old-school tools—paperwork, slow apps, isolated networks—while clients demand transparency. Data shows 91% of pros see automation as key, but most platforms are clunky or public-facing. AI Real Estate Pro delivers a pro-only, mobile-first solution with trends like virtual tours (74% buyer use) and AI analytics ($15B market by 2027). The shift to digital real estate makes this the perfect moment to launch. Why Now?
+Real estate pros are stuck with outdated tools—paper plans, clunky apps, scattered networks—while clients want transparency. Data shows 91% of pros see automation as critical, but most platforms are too complex or open to everyone. AI Real Estate Pro delivers a pro-only, mobile-first solution, riding trends like virtual tours (74% buyer use) and AI analytics ($15B market by 2027). With real estate shifting online, the timing is perfect.
+Key Features in Plain English
+AI Real Estate Pro is a pro’s command center, with five easy tools:
+•  Find & Tour Homes: Search Zillow or MLS, view with Google Street View or Matterport 3D tours, skipping in-person visits.
+•  AI Valuations: Get instant home values with Zillow’s Zestimate and local data, nailing offers.
+•  Sign Securely: Use DocuSign to sign contracts, with AI spotting risks, speeding closings.
+•  Schedule Smart: Book meetings with AI picking perfect times via Google Calendar.
+•  Connect & Store: Text, email, or video call (Twilio, SendGrid, Zoom); save files in AWS S3 with AI tags.
+•  PlanScanner: Scan blueprints or homes with phone/drone, saving 50% on plan prep for pros like aerial videographers.
+•  Social Network: Connect with pros, share projects, and build your rep in-app, boosting leads by 20%.
+•  Carfax-Style History: Public portal shows a home’s past—maintenance, damage, permits, contractor ratings—drawing clients.
+Only licensed pros access these tools, while the public sees the history, fueling demand.
+Who We’re Targeting
+We’re built for licensed real estate pros and tradesmen:
+•  Realtors: Close 25% faster, save 17 hours/week ($850 value).
+•  Lenders: Approve loans 20% quicker with AI valuations.
+•  Inspectors: Cut report time 50% with AI checklists.
+•  Aerial Real Estate Videographers: Create 3D tours 30% faster with PlanScanner and Matterport, boosting listings.
+•  Contractors/Tradesmen: Win 20% more jobs via 5-star ratings.
+•  Title/Escrow Pros: Save 3 hours/week with AI title checks.
+•  Architects/Draftsmen: Share e-plans 50% faster.
+•  Investors: Boost ROI 15% with AI analytics.
+•  Others: Engineers, property managers, insurance agents, warranty providers.
+The public views the history portal, driving leads to pros, tapping a $1.2 trillion construction market.
+Marketing Strategy: Winning Pros & Clients
+Our lean plan turns fear into opportunity and greed into action:
+•  Social Media & Content: Daily LinkedIn/Instagram posts with Canva visuals showcase PlanScanner and the social network. Videos like “Aerial Videographers Thrive with AI!” ease fears, using 67% social media lead reliance. Budget: $2,000/month ads.
+•  SEO & Ads: Optimize for “aerial real estate videographer” and “home history,” driving traffic. Google/LinkedIn ads target CA, TX for 4:1 ROI ($3,000/month).
+•  Email Marketing: Weekly HubSpot newsletters convert 25% of 6-month free trial users, pitching “Work Less, Earn More!”
+•  Public Portal: Promote Carfax-style history on X and YouTube, with “See Your Home’s Safe History!” driving client leads.
+•  Social Network: Encourage pros to join, sharing aerial videos to gain visibility.
+•  Investor Pitch: Pitch at NAR summits, highlighting $500,000 ARR and the social network’s lead potential.
+Competitive Edge
+•  Pro-Only Access: Licensed pros only, easing AI fears.
+•  Social Network: Built-in community boosts collaboration.
+•  Carfax-Style Transparency: Public history builds trust.
+•  Affordable: $6-$100/mo vs. Clio ($39), Qualia ($100+).
+•  Simple: Five modules cut learning curve by 30%.
+Revenue Model
+•  Basic ($6/mo): Search, tours, scheduling.
+•  Pro ($50/mo): Basic + e-signatures, AI tools, 10GB storage.
+•  Enterprise ($100/mo): Pro + unlimited storage, custom AI.
+•  Free Trial: 6-month trial converts 25%, targeting 1,000 users ($500,000 ARR).
+Why Invest?
+With a $10,000/month budget, we’ll hit 500 users by Month 12, scaling to 2,500 by Month 24. The social network and carfax style data collection for homes, focus turn AI fears into profits, offering investors a stake in a booming market.


### PR DESCRIPTION
Imagine a single app that’s like Mission Control for real estate—making buying, selling, or financing homes as easy as a few taps. AI Real Estate Pro is that app, a game-changer for approved specialist, professionals,realtors, lenders, inspectors, must have licensed tradesmen/contractors. We include a Carfax data collection hub for the general public.  Integrates, camtoplans link for E-plan development, Zillow, Matterport, DocuSign, Twilio, and Grok 3 AI to save time and close deals faster. With a $112 billion real estate tech market growing at 8.6% annually, this is a golden opportunity for angel investors to back a scalable platform set to disrupt a fragmented industry.